### PR TITLE
chore: remove local preview image

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,11 +10,9 @@
     <meta property="og:title" content="Apps Are Fun — iOS App Development That Drives Results" />
     <meta property="og:description" content="Transform your business with custom iOS apps. Expert SwiftUI development, App Store optimization, and proven results. From startups to enterprise - we deliver profitable mobile solutions." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <meta property="og:url" content="https://appsare.fun" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@appsarefun" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- remove binary Open Graph image to avoid unsupported files
- rely on text-only metadata for social previews

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b778e6f2ac8328b21fff8d96321339