### PR TITLE
Add parallax header and card hover effects

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -24,9 +24,9 @@ const AboutSection = () => {
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 opacity-0 animate-[fadeInUp_0.7s_ease-out_0.2s_forwards]">
           {pillars.map((pillar, index) => (
-            <div 
-              key={index} 
-              className="flex items-center gap-3 p-4 rounded-xl bg-gradient-subtle border border-border/50"
+            <div
+              key={index}
+              className="flex items-center gap-3 p-4 rounded-xl bg-gradient-subtle border border-border/50 transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-hover)]"
             >
               <CheckCircle className="h-6 w-6 text-secondary flex-shrink-0" />
               <span className="text-foreground font-medium">{pillar}</span>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,18 +1,51 @@
 import { Button } from "@/components/ui/button";
 import { ArrowDown } from "lucide-react";
+import { useEffect, useRef } from "react";
 
 const HeroSection = () => {
   const scrollToSection = (id: string) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
   };
+
+  // Parallax background elements
+  const parallaxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const offset = window.scrollY;
+      const layers = parallaxRef.current?.children;
+      if (!layers) return;
+      Array.from(layers).forEach((layer) => {
+        const speed = parseFloat(
+          (layer as HTMLElement).dataset.speed || "0"
+        );
+        (layer as HTMLElement).style.transform = `translateY(${offset * speed}px)`;
+      });
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   return (
     <section className="hero-section flex items-center justify-center relative overflow-hidden">
-      {/* Background decorative elements */}
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute top-20 left-10 w-32 h-32 bg-white/10 rounded-full blur-xl"></div>
-        <div className="absolute bottom-32 right-16 w-48 h-48 bg-white/5 rounded-full blur-2xl"></div>
-        <div className="absolute top-1/2 left-1/3 w-24 h-24 bg-white/15 rounded-full blur-lg"></div>
+      {/* Background decorative elements with parallax */}
+      <div
+        ref={parallaxRef}
+        className="absolute inset-0 overflow-hidden pointer-events-none"
+      >
+        <div
+          data-speed="-0.3"
+          className="absolute top-20 left-10 w-32 h-32 bg-white/10 rounded-full blur-xl will-change-transform"
+        ></div>
+        <div
+          data-speed="0.25"
+          className="absolute bottom-32 right-16 w-48 h-48 bg-white/5 rounded-full blur-2xl will-change-transform"
+        ></div>
+        <div
+          data-speed="-0.15"
+          className="absolute top-1/2 left-1/3 w-24 h-24 bg-white/15 rounded-full blur-lg will-change-transform"
+        ></div>
       </div>
       
       <div className="container mx-auto px-4 text-center text-white relative z-10 opacity-0 animate-[fadeInUp_0.7s_ease-out_forwards]">

--- a/src/components/ProcessSection.tsx
+++ b/src/components/ProcessSection.tsx
@@ -43,9 +43,9 @@ const ProcessSection = () => {
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-8">
           {steps.map((step, index) => (
-            <div 
-              key={index} 
-              className="text-center opacity-0 animate-[fadeInUp_0.7s_ease-out_forwards] relative"
+            <div
+              key={index}
+              className="text-center p-6 rounded-xl border border-border/50 bg-card transition-all duration-300 hover:-translate-y-1 hover:shadow-[var(--shadow-hover)] opacity-0 animate-[fadeInUp_0.7s_ease-out_forwards] relative"
               style={{ animationDelay: `${index * 0.1 + 0.2}s` }}
             >
               <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 text-primary mb-4">
@@ -57,7 +57,7 @@ const ProcessSection = () => {
               <p className="text-sm text-muted-foreground">
                 {step.description}
               </p>
-              
+
               {/* Arrow connector for larger screens */}
               {index < steps.length - 1 && (
                 <div className="hidden lg:block absolute top-8 -right-4 text-muted-foreground/30">

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -44,9 +44,9 @@ const ServicesSection = () => {
         
         <div className="space-y-4 mb-12 opacity-0 animate-[fadeInUp_0.7s_ease-out_0.2s_forwards]">
           {capabilities.map((capability, index) => (
-            <div 
-              key={index} 
-              className="flex items-center gap-4 p-4 rounded-xl border border-border/50 bg-card hover:bg-gradient-subtle transition-colors duration-200"
+            <div
+              key={index}
+              className="flex items-center gap-4 p-4 rounded-xl border border-border/50 bg-card transition-all duration-300 hover:bg-gradient-subtle hover:-translate-y-1 hover:shadow-[var(--shadow-hover)]"
             >
               <capability.icon className="h-6 w-6 text-primary flex-shrink-0" />
               <span className="text-foreground">{capability.text}</span>


### PR DESCRIPTION
## Summary
- Introduce scroll-driven parallax motion to hero background elements for a lively header
- Enhance about, services, and process listings with card-style hover shadows and lift

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4455710488328abd1d45607e95308